### PR TITLE
DP-1322 Add pipeline processor ID field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## ?.?.?
+
+* `PipelineInstance` now takes an optional parameter `pipelineProcessorId`,
+  intended to supersede `pipelineArn` once all users have been updated. The
+  `pipelineArn` parameter is now optional.
+
 ## 0.2.7
 
 * Enable, disable and get event stream sinks by *type* (not id).

--- a/origo/pipelines/client.py
+++ b/origo/pipelines/client.py
@@ -43,13 +43,13 @@ class PipelineApiClient(SDK):
     def get_pipeline_input(
         self, pipelineInstanceId: str, dataset: str, version: str
     ) -> List[PipelineInput]:
-        return PipelineInstance(
-            self, pipelineInstanceId, "", "", "", "", False
-        ).get_input(dataset, version)
+        return PipelineInstance(self, pipelineInstanceId, "", "", "", False).get_input(
+            dataset, version
+        )
 
     def get_pipeline_inputs(self, pipelineInstanceId: str) -> List[PipelineInput]:
         return PipelineInstance(
-            self, pipelineInstanceId, "", "", "", "", False
+            self, pipelineInstanceId, "", "", "", False
         ).get_inputs()
 
     def create_pipeline(self, data: dict):

--- a/origo/pipelines/resources/pipeline_instance.py
+++ b/origo/pipelines/resources/pipeline_instance.py
@@ -17,6 +17,7 @@ class PipelineInstance(PipelineBase):
             Defines what dataset + version this pipeline instance should result in. e.g. Running the pipeline instance
             should create a new edition in this dataset + version combination.
         pipelineArn: What Pipeline should be used.
+        pipelineProcessorId: ID of the pipeline processor to use.
         schemaId: Id for a schema. Used to validate the input or output.
             TODO: For now it's up to the pipeline to include a validation step. So this might not be in use even if supplied.
         transformation: object Transformation for the given Pipeline. Should include config for each step in
@@ -35,16 +36,21 @@ class PipelineInstance(PipelineBase):
         sdk: SDK,
         id: str,
         datasetUri: str,
-        pipelineArn: str,
         schemaId: str,
         taskConfig: object,
         useLatestEdition: bool,
+        # TODO: Remove this once all users have been updated to use
+        # `pipelineProcessorId` instead.
+        pipelineArn: str = None,
+        # TODO: Make this required once `pipelineArn` has been phased out.
+        pipelineProcessorId: str = None,
         transformation: object = None,
     ):
         self.sdk = sdk
         self._id = id
         self.datasetUri = datasetUri
         self.pipelineArn = pipelineArn
+        self.pipelineProcessorId = pipelineProcessorId
         self.schemaId = schemaId
         self.transformation = transformation
         self.taskConfig = taskConfig
@@ -55,11 +61,14 @@ class PipelineInstance(PipelineBase):
         dictionary = {
             "id": self.id,
             "datasetUri": self.datasetUri,
-            "pipelineArn": self.pipelineArn,
             "schemaId": self.schemaId,
             "taskConfig": self.taskConfig,
             "useLatestEdition": self.useLatestEdition,
         }
+        if self.pipelineArn is not None:
+            dictionary["pipelineArn"] = self.pipelineArn
+        if self.pipelineProcessorId is not None:
+            dictionary["pipelineProcessorId"] = self.pipelineProcessorId
         if self.transformation is not None:
             dictionary["transformation"] = self.transformation
         return dictionary

--- a/origo/pipelines/resources/schemas/pipeline-instances.json
+++ b/origo/pipelines/resources/schemas/pipeline-instances.json
@@ -7,7 +7,6 @@
   "required": [
     "id",
     "datasetUri",
-    "pipelineArn",
     "schemaId",
     "taskConfig",
     "useLatestEdition"


### PR DESCRIPTION
Add a `pipelineProcessorId` field to the `PipelineInstance`, intended to supersede `pipelineArn` once all users have been updated. Also make `pipelineArn` optional.