### PR TITLE
DP-1378 Remove obsolete pipeline instance fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
   intended to supersede `pipelineArn` once all users have been updated. The
   `pipelineArn` parameter is now optional.
 
+* The `taskConfig` to `PipelineInstance` is now also optional.
+
+* `PipelineInstance` no longer accepts the obsolete parameters `schemaId` and
+  `useLatestEdition`.
+
 ## 0.2.7
 
 * Enable, disable and get event stream sinks by *type* (not id).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 * The `taskConfig` to `PipelineInstance` is now also optional.
 
-* `PipelineInstance` no longer accepts the obsolete parameters `schemaId` and
-  `useLatestEdition`.
+* `PipelineInstance` no longer accepts the obsolete parameters `schemaId`,
+  `transformation`, and `useLatestEdition`.
 
 ## 0.2.7
 

--- a/origo/pipelines/client.py
+++ b/origo/pipelines/client.py
@@ -43,12 +43,12 @@ class PipelineApiClient(SDK):
     def get_pipeline_input(
         self, pipelineInstanceId: str, dataset: str, version: str
     ) -> List[PipelineInput]:
-        return PipelineInstance(self, pipelineInstanceId, "", "", False).get_input(
+        return PipelineInstance(self, pipelineInstanceId, "").get_input(
             dataset, version
         )
 
     def get_pipeline_inputs(self, pipelineInstanceId: str) -> List[PipelineInput]:
-        return PipelineInstance(self, pipelineInstanceId, "", "", False).get_inputs()
+        return PipelineInstance(self, pipelineInstanceId, "").get_inputs()
 
     def create_pipeline(self, data: dict):
         created, error = Pipeline.from_dict(self, data).create()

--- a/origo/pipelines/resources/pipeline_instance.py
+++ b/origo/pipelines/resources/pipeline_instance.py
@@ -18,11 +18,8 @@ class PipelineInstance(PipelineBase):
             should create a new edition in this dataset + version combination.
         pipelineArn: What Pipeline should be used.
         pipelineProcessorId: ID of the pipeline processor to use.
-        schemaId: Id for a schema. Used to validate the input or output.
-            TODO: For now it's up to the pipeline to include a validation step. So this might not be in use even if supplied.
         transformation: object Transformation for the given Pipeline. Should include config for each step in
             the state-machine if needed. Should be validated against Pipeline.transformation_schema
-        useLatestEdition: bool Whether or not to create a new edition or use the latest edition when running the pipeline.
     """
 
     __resource_name__ = "pipeline-instances"
@@ -36,8 +33,6 @@ class PipelineInstance(PipelineBase):
         sdk: SDK,
         id: str,
         datasetUri: str,
-        schemaId: str,
-        useLatestEdition: bool,
         taskConfig: object = None,
         # TODO: Remove this once all users have been updated to use
         # `pipelineProcessorId` instead.
@@ -51,19 +46,15 @@ class PipelineInstance(PipelineBase):
         self.datasetUri = datasetUri
         self.pipelineArn = pipelineArn
         self.pipelineProcessorId = pipelineProcessorId
-        self.schemaId = schemaId
         self.transformation = transformation
         self.taskConfig = taskConfig
-        self.useLatestEdition = useLatestEdition
 
     @property
     def __dict__(self):
         dictionary = {
             "id": self.id,
             "datasetUri": self.datasetUri,
-            "schemaId": self.schemaId,
             "taskConfig": self.taskConfig,
-            "useLatestEdition": self.useLatestEdition,
         }
         if self.taskConfig is not None:
             dictionary["taskConfig"] = self.taskConfig

--- a/origo/pipelines/resources/pipeline_instance.py
+++ b/origo/pipelines/resources/pipeline_instance.py
@@ -18,8 +18,6 @@ class PipelineInstance(PipelineBase):
             should create a new edition in this dataset + version combination.
         pipelineArn: What Pipeline should be used.
         pipelineProcessorId: ID of the pipeline processor to use.
-        transformation: object Transformation for the given Pipeline. Should include config for each step in
-            the state-machine if needed. Should be validated against Pipeline.transformation_schema
     """
 
     __resource_name__ = "pipeline-instances"
@@ -39,14 +37,12 @@ class PipelineInstance(PipelineBase):
         pipelineArn: str = None,
         # TODO: Make this required once `pipelineArn` has been phased out.
         pipelineProcessorId: str = None,
-        transformation: object = None,
     ):
         self.sdk = sdk
         self._id = id
         self.datasetUri = datasetUri
         self.pipelineArn = pipelineArn
         self.pipelineProcessorId = pipelineProcessorId
-        self.transformation = transformation
         self.taskConfig = taskConfig
 
     @property
@@ -62,9 +58,30 @@ class PipelineInstance(PipelineBase):
             dictionary["pipelineArn"] = self.pipelineArn
         if self.pipelineProcessorId is not None:
             dictionary["pipelineProcessorId"] = self.pipelineProcessorId
-        if self.transformation is not None:
-            dictionary["transformation"] = self.transformation
         return dictionary
+
+    @classmethod
+    def from_dict(cls, sdk: SDK, instance_dict: dict):
+        """Create and return a pipeline instance from a dictionary.
+
+        Overrides the method from `PipelineBase` to be able to pick and choose
+        from `instance_dict`, instead of requiring an exact match with this
+        class' `___init___` parameters.
+        """
+        return cls(
+            sdk,
+            **{
+                key: instance_dict[key]
+                for key in [
+                    "id",
+                    "datasetUri",
+                    "taskConfig",
+                    "pipelineArn",
+                    "pipelineProcessorId",
+                ]
+                if key in instance_dict
+            },
+        )
 
     def __repr__(self):
         return json.dumps(self.__dict__)

--- a/origo/pipelines/resources/schemas/pipeline-instances.json
+++ b/origo/pipelines/resources/schemas/pipeline-instances.json
@@ -33,11 +33,6 @@
       ],
       "pattern": "^arn:aws:states:eu-west-1:[0-9]{12}:stateMachine:[-a-z]*$"
     },
-    "transformation": {
-      "$id": "#/properties/transformation",
-      "type": "object",
-      "title": "The Transformation Schema"
-    },
     "taskCofig": {
       "$id": "#/properties/transformation",
       "type": "object",

--- a/origo/pipelines/resources/schemas/pipeline-instances.json
+++ b/origo/pipelines/resources/schemas/pipeline-instances.json
@@ -6,9 +6,7 @@
   "title": "The Root Schema",
   "required": [
     "id",
-    "datasetUri",
-    "schemaId",
-    "useLatestEdition"
+    "datasetUri"
   ],
   "properties": {
     "id": {
@@ -35,13 +33,6 @@
       ],
       "pattern": "^arn:aws:states:eu-west-1:[0-9]{12}:stateMachine:[-a-z]*$"
     },
-    "schemaId": {
-      "$id": "#/properties/schemaId",
-      "type": "string",
-      "title": "The Schemaid Schema",
-      "default": "",
-      "pattern": "^(.*)$"
-    },
     "transformation": {
       "$id": "#/properties/transformation",
       "type": "object",
@@ -51,15 +42,6 @@
       "$id": "#/properties/transformation",
       "type": "object",
       "title": "The Transformation Schema"
-    },
-    "useLatestEdition": {
-      "$id": "#/properties/useLatestEdition",
-      "type": "boolean",
-      "title": "The Uselatestedition Schema",
-      "default": false,
-      "examples": [
-        true
-      ]
     }
   }
 }

--- a/tests/origio/pipeline/pipeline_instance/pipeline_instance_test.py
+++ b/tests/origio/pipeline/pipeline_instance/pipeline_instance_test.py
@@ -11,6 +11,16 @@ def test_create_pipeline_instance_from_json(sdk, mock_create_pipeline_instance):
     assert response == '"pipeline-instance-id"'
 
 
+def test_pipeline_instance_from_json_unknown_keyword():
+    client = PipelineApiClient()
+    raw = json.loads(create_pipeline_instance_request())
+    raw["transformation"] = "this keyword is unknown"
+    instance = PipelineInstance.from_json(client, json.dumps(raw))
+    validated, error = instance.validate()
+    assert validated
+    assert error is None
+
+
 def test_create_pipeline_instance_basic(sdk, mock_create_pipeline_instance):
     instance_input = json.loads(create_pipeline_instance_request())
     instance = PipelineInstance(sdk, **instance_input)
@@ -32,14 +42,3 @@ def test_get_pipeline_instance(mock_get_pipeline_instance):
     instance = client.fetch(PipelineInstance, "pipeline-instance-id")
     expected = json.loads(create_pipeline_instance_request())
     assert instance.taskConfig == expected["taskConfig"]
-
-
-def test_pipeline_instance_with_optional_transformation():
-    client = PipelineApiClient()
-    raw = json.loads(create_pipeline_instance_request())
-    raw["transformation"] = {"some transformation": "here"}
-    instance = PipelineInstance.from_json(client, json.dumps(raw))
-    validated, error = instance.validate()
-    assert validated
-    assert error is None
-    assert raw["transformation"] == instance.transformation

--- a/tests/origio/pipeline/pipeline_instance/request.json
+++ b/tests/origio/pipeline/pipeline_instance/request.json
@@ -2,9 +2,7 @@
     "id": "pipeline-instance-id",
     "datasetUri": "output/pipeline-instance-id/1",
     "pipelineArn": "arn:aws:states:eu-west-1:123456789101:stateMachine:test-pipeline-excel-to-csv",
-    "schemaId": "pipeline-instance-id",
     "taskConfig": {
         "json_transformer": {}
-    },
-    "useLatestEdition": true
+    }
 }

--- a/tests/origio/pipeline/test_example.py
+++ b/tests/origio/pipeline/test_example.py
@@ -65,6 +65,5 @@ def test_bootstrap_script(
     assert not valid
     assert error.message.startswith("'boligpriser' does not match ")
     instance.datasetUri = "output/boligpriser/1"
-    instance.transformation = {"transformation": "goes here"}
     instance.create()
     assert mock_create_pipeline_instance.called

--- a/tests/origio/pipeline/test_example.py
+++ b/tests/origio/pipeline/test_example.py
@@ -33,7 +33,6 @@ def test_resource_example(
         assert errors.message == "12314 is not of type 'string'"
 
     instance: PipelineInstance = instances[0]
-    instance.schemaId = "blabla"
     instance.create()
 
     assert mock_create_pipeline_instance.called
@@ -59,10 +58,8 @@ def test_bootstrap_script(
         sdk,
         id="uuid?",
         datasetUri="boligpriser",
-        schemaId="coming soon",
         taskConfig="transformation goes here",
         pipelineArn=pipeline.arn,
-        useLatestEdition=True,
     )
     valid, error = instance.validate()
     assert not valid


### PR DESCRIPTION
Remove the `schemaId` and `useLatestEdition` fields from the `PipelineInstance` class as they no longer have any function.